### PR TITLE
dont fail if no ssh-key is provided

### DIFF
--- a/lib/puppet/provider/hetzner_server/hcloud.rb
+++ b/lib/puppet/provider/hetzner_server/hcloud.rb
@@ -38,7 +38,7 @@ Puppet::Type.type(:hetzner_server).provide(:hcloud) do
       array << resource[:location]
     end
 
-    if resource[:ssh_keys].count > 0
+    unless resource[:ssh_keys].to_a.empty?
       Puppet.debug("ssh_keys property has the value #{resource[:ssh_keys]}")
       resource[:ssh_keys].each do |key|
         array << '--ssh-key'


### PR DESCRIPTION
before this change, we would get a NilClass NoMethodError. We always
tried to add a ssh-key, even if none was provided. This is now fixed.